### PR TITLE
[UI] 회원가입 UI 구현 (#5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "prettier": "^3.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.52.0",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -16804,6 +16805,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.3.2",
         "react": "^18.3.1",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
@@ -16598,6 +16599,15 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "prettier": "^3.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-hook-form": "^7.52.0",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -16805,22 +16804,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
-    },
-    "node_modules/react-hook-form": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
-      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "prettier": "^3.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-hook-form": "^7.52.0",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prettier": "^3.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.0",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.3.2",
     "react": "^18.3.1",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",

--- a/src/components/Join/AddressInput.tsx
+++ b/src/components/Join/AddressInput.tsx
@@ -1,0 +1,87 @@
+import React, { ChangeEvent, useState } from 'react';
+import DaumPostcode from 'react-daum-postcode';
+
+const AddressInput = () => {
+  const [zonecode, setZonecode] = useState('');
+  const [address, setAddress] = useState('');
+  const [detailAddress, setDetailAddress] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const completeHandler = (data: AddressData) => {
+    console.log(data);
+    const { zonecode, address } = data;
+    setZonecode(zonecode);
+    setAddress(address);
+  };
+
+  const closeHandler = () => {
+    setIsOpen(false);
+  };
+
+  const toggleHandler = () => {
+    setIsOpen((prevOpen) => !prevOpen);
+  };
+
+  const inputChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    setDetailAddress(e.target.value);
+  };
+
+  const postCodeStyle = {
+    width: '400px',
+    height: '480px',
+  };
+
+  return (
+    <>
+      <label
+        htmlFor="nickname"
+        className="block text-gray-700 text-m font-bold mb-2"
+      >
+        주소<span className="text-red-600">*</span>
+      </label>
+      <div className="flex flex-col">
+        <div className="flex">
+          <div
+            className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight placeholder:text-sm focus:outline-none focus:shadow-outline w-full"
+            onClick={toggleHandler}
+          >
+            {zonecode}
+          </div>
+          <button
+            type="button"
+            onClick={toggleHandler}
+            className="bg-[#5EC7B8] hover:bg-[#2E9093] text-white text-sm rounded min-w-[140px] px-4 py-2 ml-4 focus:outline-none focus:shadow-outline"
+          >
+            우편번호 검색
+          </button>
+        </div>
+        <div className="appearance-none border h-[35px] rounded-l mt-4 py-2 px-3 text-gray-700 leading-tight mb-4 placeholder:text-sm focus:outline-none focus:shadow-outline">
+          {address}
+        </div>
+      </div>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="fixed inset-0 bg-gray-500 bg-opacity-50 backdrop-blur"
+            onClick={closeHandler}
+          ></div>
+          <DaumPostcode
+            style={postCodeStyle}
+            onComplete={completeHandler}
+            onClose={closeHandler}
+          />
+        </div>
+      )}
+      <div className="flex flex-col">
+        <input
+          value={detailAddress}
+          onChange={inputChangeHandler}
+          placeholder="상세 주소를 입력하세요."
+          className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight mb-4 placeholder:text-sm focus:outline-none focus:shadow-outline"
+        />
+      </div>
+    </>
+  );
+};
+
+export default AddressInput;

--- a/src/components/Join/EmailInput.tsx
+++ b/src/components/Join/EmailInput.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import useModal from '../../hooks/useModal';
+import useInput from '../../hooks/useInput';
+
+const EmailInput = () => {
+  const emailInput = useInput({ initialValue: '' });
+
+  const { openModal, Modal, closeModal } = useModal();
+
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/; // 이메일 조건
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+  const [isDuplicate, setIsDuplicate] = useState(true); // 중복 검사
+
+  const handleEmail = () => {
+    // 이메일 중복 확인
+    openModal();
+  };
+
+  return (
+    <>
+      <label
+        htmlFor="email"
+        className="block text-gray-700 text-m font-bold mb-2"
+      >
+        이메일<span className="text-red-600">*</span>
+      </label>
+      <div className="flex">
+        <input
+          type="text"
+          id="nickname"
+          name="nickname"
+          placeholder="이메일을 입력하세요"
+          value={emailInput.value}
+          onChange={emailInput.onChange}
+          className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight placeholder:text-sm focus:outline-none focus:shadow-outline w-full"
+        />
+        <button
+          type="button"
+          onClick={handleEmail}
+          className="bg-[#5EC7B8] hover:bg-[#2E9093] text-white rounded min-w-[120px] px-4 py-2 ml-4 focus:outline-none focus:shadow-outline"
+        >
+          중복 확인
+        </button>
+      </div>
+      <p
+        className={`text-xs mt-4 ${isValid ? 'text-gray-400' : 'text-red-600'}`}
+      >
+        {isValid
+          ? '사용 가능한 특수문자는 (_/-/@/.)입니다.'
+          : '잘못된 형식의 이메일입니다.'}
+      </p>
+
+      {/* Modal */}
+      <Modal style={{ width: '400px', height: '220px' }}>
+        <div>
+          <div className="mt-8 mb-8 text-xl text-[#257276]">
+            {isValid
+              ? isDuplicate
+                ? '확인되었습니다'
+                : '이메일이 중복됩니다. 다른 이메일을 입력해주세요.'
+              : '잘못된 형식의 이메일입니다.'}
+          </div>
+          <button
+            onClick={closeModal}
+            className="bg-[#2E9093] hover:bg-[#257276] w-full text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            확인
+          </button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default EmailInput;

--- a/src/components/Join/NicknameInput.tsx
+++ b/src/components/Join/NicknameInput.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import useInput from '../../hooks/useInput';
+import useModal from '../../hooks/useModal';
+
+const NicknameInput = () => {
+  const nicknameInput = useInput({ initialValue: '' });
+
+  const { openModal, Modal, closeModal } = useModal();
+
+  const nicknameRegex = /^[a-zA-Z0-9]{1,5}$/; // 닉네임 조건
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+  const [isDuplicate, setIsDuplicate] = useState(true); // 중복 검사
+
+  const handleNickname = () => {
+    // 닉네임 중복 확인
+    openModal();
+  };
+
+  return (
+    <>
+      <label
+        htmlFor="nickname"
+        className="block text-gray-700 text-m font-bold mb-2"
+      >
+        닉네임<span className="text-red-600">*</span>
+      </label>
+      <div className="flex">
+        <input
+          type="text"
+          id="nickname"
+          name="nickname"
+          placeholder="닉네임을 입력하세요"
+          value={nicknameInput.value}
+          onChange={nicknameInput.onChange}
+          className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight placeholder:text-sm focus:outline-none focus:shadow-outline w-full"
+        />
+        <button
+          type="button"
+          onClick={handleNickname}
+          className="bg-[#5EC7B8] hover:bg-[#2E9093] text-white rounded min-w-[120px] px-4 py-2 ml-4 focus:outline-none focus:shadow-outline"
+        >
+          중복 확인
+        </button>
+      </div>
+      <p
+        className={`text-xs mt-4 ${isValid ? 'text-gray-400' : 'text-red-600'}`}
+      >
+        {isValid
+          ? '최대 5글자까지 허용 (특수문자는 사용하실 수 없습니다)'
+          : '잘못된 형식의 닉네임입니다.'}
+      </p>
+
+      {/* Modal */}
+      <Modal style={{ width: '400px', height: '220px' }}>
+        <div className="flex flex-col items-center justify-center">
+          <div className="mt-8 mb-8 text-xl text-[#257276]">
+            {isValid
+              ? isDuplicate
+                ? '확인되었습니다'
+                : '닉네임이 중복됩니다. 다른 닉네임을 입력해주세요.'
+              : '잘못된 형식의 닉네임입니다.'}
+          </div>
+          <button
+            onClick={closeModal}
+            className="bg-[#2E9093] hover:bg-[#257276] w-full text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            확인
+          </button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default NicknameInput;

--- a/src/components/Join/PasswordInput.tsx
+++ b/src/components/Join/PasswordInput.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import useInput from '../../hooks/useInput';
+
+const PasswordInput = () => {
+  const passwordInput = useInput({ initialValue: '' });
+  const passwordCheckInput = useInput({ initialValue: '' });
+
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d|[\W_]).{8,13}$/; // 비밀번호 조건
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+  const [isDuplicate, setIsDuplicate] = useState(true); // 중복 검사
+
+  return (
+    <>
+      <label
+        htmlFor="password"
+        className="block text-gray-700 text-m font-bold mb-2"
+      >
+        비밀번호<span className="text-red-600">*</span>
+      </label>
+      <div className="flex flex-col">
+        <input
+          type="text"
+          id="nickname"
+          name="nickname"
+          placeholder="비밀번호를 입력하세요"
+          value={passwordInput.value}
+          onChange={passwordInput.onChange}
+          className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight mb-4 placeholder:text-sm focus:outline-none focus:shadow-outline"
+        />
+        <input
+          type="text"
+          id="nickname"
+          name="nickname"
+          placeholder="비밀번호를 다시 한 번 입력하세요"
+          value={passwordCheckInput.value}
+          onChange={passwordCheckInput.onChange}
+          className="appearance-none border rounded-l py-2 px-3 text-gray-700 leading-tight placeholder:text-sm focus:outline-none focus:shadow-outline"
+        />
+      </div>
+      <p
+        className={`text-xs mt-4 ${isValid ? 'text-gray-400' : 'text-red-600'}`}
+      >
+        {isValid
+          ? '영문,숫자,특수문자를 포함하여 8-13자로 입력해주세요.'
+          : '잘못된 형식의 비밀번호입니다.'}
+      </p>
+    </>
+  );
+};
+
+export default PasswordInput;

--- a/src/components/Join/UserTypeSelection.tsx
+++ b/src/components/Join/UserTypeSelection.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const UserTypeSelection = () => {
+  return (
+    <>
+      <label
+        htmlFor="usertype"
+        className="block text-gray-700 text-m font-bold mb-2"
+      >
+        이메일<span className="text-red-600">*</span>
+      </label>
+      <div className="flex">
+        <div className="flex items-center mb-2">
+          <input
+            className="appearance-none w-3 h-3 mr-2 border border-gray-300 rounded-full checked:bg-[#2E9093] focus:outline-none"
+            type="radio"
+            name="userType"
+            id="radioSeller"
+          />
+          <label className="cursor-pointer text-sm mr-6" htmlFor="radioSeller">
+            판매자
+          </label>
+        </div>
+        <div className="flex items-center mb-2">
+          <input
+            className="appearance-none w-3 h-3 mr-2 border border-gray-300 rounded-full checked:bg-[#2E9093] focus:outline-none"
+            type="radio"
+            name="userType"
+            id="radioBuyer"
+            defaultChecked
+          />
+          <label className="cursor-pointer text-sm" htmlFor="radioBuyer">
+            구매자
+          </label>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default UserTypeSelection;

--- a/src/components/Join/UserTypeSelection.tsx
+++ b/src/components/Join/UserTypeSelection.tsx
@@ -5,9 +5,9 @@ const UserTypeSelection = () => {
     <>
       <label
         htmlFor="usertype"
-        className="block text-gray-700 text-m font-bold mb-2"
+        className="block text-gray-700 text-m font-bold mb-3"
       >
-        이메일<span className="text-red-600">*</span>
+        회원 유형 선택<span className="text-red-600">*</span>
       </label>
       <div className="flex">
         <div className="flex items-center mb-2">

--- a/src/components/Join/UserTypeSelection.tsx
+++ b/src/components/Join/UserTypeSelection.tsx
@@ -27,7 +27,6 @@ const UserTypeSelection = () => {
             type="radio"
             name="userType"
             id="radioBuyer"
-            defaultChecked
           />
           <label className="cursor-pointer text-sm" htmlFor="radioBuyer">
             구매자

--- a/src/components/Join/index.ts
+++ b/src/components/Join/index.ts
@@ -1,0 +1,13 @@
+import UserTypeSelection from './UserTypeSelection';
+import NicknameInput from './NicknameInput';
+import EmailInput from './EmailInput';
+import PasswordInput from './PasswordInput';
+import AddressInput from './AddressInput';
+
+export {
+  UserTypeSelection,
+  NicknameInput,
+  EmailInput,
+  PasswordInput,
+  AddressInput,
+};

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -1,0 +1,27 @@
+import { useState, ChangeEvent } from 'react';
+
+type InputEvent = ChangeEvent<HTMLInputElement>;
+
+interface UseInputOptions {
+  initialValue?: string;
+}
+
+const useInput = ({ initialValue = '' }: UseInputOptions = {}) => {
+  const [value, setValue] = useState<string>(initialValue);
+
+  const handleChange = (e: InputEvent) => {
+    setValue(e.target.value);
+  };
+
+  const reset = () => {
+    setValue('');
+  };
+
+  return {
+    value,
+    onChange: handleChange,
+    reset,
+  };
+};
+
+export default useInput;

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+interface ModalProps {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export default function useModal() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // modal open
+  const openModal = () => {
+    setIsModalOpen(true);
+    document.body.style.overflow = 'hidden';
+  };
+
+  // modal close
+  const closeModal = () => {
+    setIsModalOpen(false);
+    document.body.style.overflow = 'unset';
+  };
+
+  // modal component
+  const Modal: React.FC<ModalProps> = ({ children, style }) => {
+    return isModalOpen ? (
+      <>
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="fixed inset-0 bg-gray-500 bg-opacity-50 backdrop-blur"
+            onClick={closeModal}
+          ></div>
+          <div
+            className="relative bg-[#ACDACD] rounded-lg p-6 mx-4 sm:max-w-lg sm:w-full"
+            style={style}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="absolute top-2 right-2 text-white mr-5"
+              onClick={closeModal}
+            >
+              x
+            </button>
+            <div className="flex flex-col items-center">{children}</div>
+          </div>
+        </div>
+      </>
+    ) : null;
+  };
+
+  return {
+    isModalOpen,
+    openModal,
+    closeModal,
+    Modal,
+  };
+}

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,7 +1,61 @@
-import React from "react";
+import { useNavigate } from 'react-router-dom';
+import {
+  AddressInput,
+  EmailInput,
+  NicknameInput,
+  PasswordInput,
+  UserTypeSelection,
+} from '../components/Join';
 
 const Join = () => {
-  return <div>join page</div>;
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form className="bg-white shadow-md rounded-lg px-10 py-8 max-w-lg w-full mt-7 mb-7">
+        <label className="text-[#2E9093] font-bold text-5xl mt-16 mb-16 text-center">
+          회원가입
+        </label>
+
+        {/* 회원가입 form */}
+        <div className="mt-6 mb-6">
+          {/* 판매자/구매자 선택 */}
+          <UserTypeSelection />
+        </div>
+
+        <div className="mb-6">
+          {/* 닉네임 */}
+          <NicknameInput />
+        </div>
+
+        <div className="mb-6">
+          {/* 이메일 */}
+          <EmailInput />
+        </div>
+
+        <div className="mb-6">
+          {/* 비밀번호 */}
+          <PasswordInput />
+        </div>
+
+        <div className="mb-6">
+          {/* 주소 입력 */}
+          <AddressInput />
+        </div>
+
+        {/* 가입 button */}
+        <div className="flex items-center justify-center">
+          <button
+            className="bg-[#2E9093] hover:bg-[#257276] w-full text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            type="button"
+            onClick={() => navigate('/')}
+          >
+            가입하기
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default Join;

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -1,0 +1,7 @@
+declare interface JoinForm {
+  userType: 'buyer' | 'seller';
+  nickname: string;
+  email: string;
+  password: string;
+  address: string;
+}

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -5,3 +5,8 @@ declare interface JoinForm {
   password: string;
   address: string;
 }
+
+declare interface AddressData {
+  zonecode: string;
+  address: string;
+}


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#5 => develop
closes #5 

## 변경 사항
![localhost_3000_join](https://github.com/web-team-dopamine/recycling-front/assets/95006849/e53bb133-4b4b-4d85-ab0b-7fab22d71211)
- `usertypeSelection`
- `nickname`, `email` input 및 중복확인
- `password` input
- kakao api 활용한 주소 찾기