### PR TITLE
[UI] 업사이클링 제품 메인 페이지 (#31)

### DIFF
--- a/src/components/ProductMain/Banner.tsx
+++ b/src/components/ProductMain/Banner.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Banner = () => {
+  return (
+    <div className="bg-white w-full h-[400px] flex items-center justify-center flex-col text-center px-4">
+      <img
+        src={`${process.env.PUBLIC_URL}/asset/com-banner.png`}
+        alt="banner"
+      />
+    </div>
+  );
+};
+
+export default Banner;

--- a/src/components/ProductMain/Item.tsx
+++ b/src/components/ProductMain/Item.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import { FaHeart, FaShoppingCart } from 'react-icons/fa'; // Importing icons for wishlist and cart
+import { useNavigate } from 'react-router-dom';
+import useModal from '../../hooks/useModal';
+
+const Item = ({ image, title, company, price }: ProductItemProps) => {
+  const navigate = useNavigate();
+  const [hovered, setHovered] = useState(false);
+
+  // 좋아요, 장바구니 추가 관련 modal
+  const {
+    openModal: openMarkModal,
+    closeModal: closeMarkModal,
+    Modal: MarkModal,
+  } = useModal();
+  const {
+    openModal: openCartModal,
+    closeModal: closeCartModal,
+    Modal: CartModal,
+  } = useModal();
+
+  // 확인 modal
+  const {
+    openModal: openConfirmModal,
+    closeModal: closeConfirmModal,
+    Modal: ConfirmModal,
+  } = useModal();
+
+  // 임의로 login 했다고 가정
+  const isLoggedIn = () => {
+    return true;
+  };
+
+  return (
+    <div
+      className="max-w-xs rounded overflow-hidden shadow-lg bg-white m-4 relative cursor-pointer"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className="relative">
+        <img className="w-full h-34 object-cover" src={image} alt={title} />
+        {hovered && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-300">
+            <div className="text-white text-center">
+              <button
+                className="text-gray-400 hover:text-red-600 mx-2"
+                onClick={openMarkModal}
+              >
+                <FaHeart className="inline-block" />
+              </button>
+              <button
+                className="text-gray-400 hover:text-[#2E9093] mx-2"
+                onClick={openCartModal}
+              >
+                <FaShoppingCart className="inline-block" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="px-4 py-4" onClick={() => navigate('/product/:id')}>
+        <div
+          className={`font-bold text-l mb-2 ${hovered ? 'hover:underline' : ''}`}
+        >
+          {title}
+        </div>
+        <p className={`text-gray-700 text-sm mb-2 `}>{company}</p>
+        <p className={`text-gray-700 text-base mb-2 `}>{price}</p>
+      </div>
+
+      {/* 찜 버튼 클릭 modal */}
+      <MarkModal>
+        {isLoggedIn() ? (
+          <>
+            <div className="text-gray-800 mb-4">
+              이 상품을 찜 리스트에 추가하시겠습니까?
+            </div>
+            <div className="flex justify-between">
+              <button
+                className="underline text-gray-800 px-4 py-2 rounded hover:text-[#2E9093]"
+                onClick={openConfirmModal}
+              >
+                예
+              </button>
+              <button
+                className="underline text-gray-800 px-4 py-2 rounded hover:text-[#2E9093]"
+                onClick={closeMarkModal}
+              >
+                아니요
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-gray-800 mb-4">로그인이 필요합니다.</div>
+            <button
+              className="bg-[#2E9093] text-white px-4 py-2 rounded hover:bg-opacity-80 mr-2"
+              onClick={() => navigate('/login')}
+            >
+              로그인하기
+            </button>
+          </>
+        )}
+      </MarkModal>
+
+      {/* 장바구니 클릭 modal */}
+      <CartModal>
+        {isLoggedIn() ? (
+          <>
+            <div className="text-gray-800 mb-4">
+              이 상품을 장바구니에 추가하시겠습니까?
+            </div>
+            <div className="flex justify-between">
+              <button
+                className="underline text-gray-800 px-4 py-2 rounded hover:text-[#2E9093]"
+                onClick={openConfirmModal}
+              >
+                예
+              </button>
+              <button
+                className="underline text-gray-800 px-4 py-2 rounded hover:text-[#2E9093]"
+                onClick={closeCartModal}
+              >
+                아니요
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-gray-800 mb-4">로그인이 필요합니다.</div>
+            <button
+              className="bg-[#2E9093] text-white px-4 py-2 rounded hover:bg-opacity-80 mr-2"
+              onClick={() => navigate('/login')}
+            >
+              로그인 하기
+            </button>
+          </>
+        )}
+      </CartModal>
+
+      {/* 확인 modal */}
+      <ConfirmModal>
+        <div className="text-gray-800 mb-4">추가되었습니다!</div>
+        <button
+          className="bg-[#2E9093] text-white px-4 py-2 rounded hover:bg-opacity-80 mr-2"
+          onClick={() => {
+            closeConfirmModal();
+            closeCartModal();
+            closeMarkModal();
+          }}
+        >
+          확인
+        </button>
+      </ConfirmModal>
+    </div>
+  );
+};
+
+export default Item;

--- a/src/components/ProductMain/ItemList.tsx
+++ b/src/components/ProductMain/ItemList.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import Item from './Item';
+import usePagination from '../../hooks/usePagination';
+import { FaChevronRight, FaChevronLeft } from 'react-icons/fa';
+
+interface ItemListProps {
+  items: {
+    id: number;
+    image: string;
+    title: string;
+    company: string;
+    price: string;
+    mark: number;
+    date: any;
+  }[];
+}
+
+const ItemList: React.FC<ItemListProps> = ({ items }) => {
+  const [sortBy, setSortBy] = useState('date'); // 초기 정렬 - 최신순
+
+  // 최신순 정렬 함수
+  const sortByDateDesc = (a: any, b: any) => b.date - a.date;
+
+  // 찜 많은 순 정렬 함수 (예시에서는 mark를 기준으로 정렬)
+  const sortByLikesDesc = (a: any, b: any) => b.mark - a.mark;
+
+  // 정렬된 아이템 배열
+  const sortedItems =
+    sortBy === 'likes'
+      ? [...items].sort(sortByLikesDesc)
+      : [...items].sort(sortByDateDesc);
+
+  // 상품 정렬 및 페이징 로직 적용
+  const {
+    currentPage,
+    currentItems,
+    totalPages,
+    paginate,
+    goToPrevPage,
+    goToNextPage,
+  } = usePagination(sortedItems, 8); // Pagination은 sortedItems에 적용
+
+  // 정렬 변경 핸들러
+  const handleSortChange = (sortType: string) => {
+    setSortBy(sortType);
+  };
+
+  return (
+    <div className="py-8 px-8 m-7">
+      {/* 정렬 버튼 */}
+      <div className="flex mb-4 ml-6">
+        <button
+          className={`mr-4 text-[#2E9093] text-m font-bold ${sortBy === 'date' ? 'text-[#2E9093]' : 'text-gray-500'}`}
+          onClick={() => handleSortChange('date')}
+        >
+          최신순
+        </button>
+        <button
+          className={`text-[#2E9093] text-m font-bold ${sortBy === 'likes' ? 'text-[#2E9093]' : 'text-gray-500'}`}
+          onClick={() => handleSortChange('likes')}
+        >
+          찜 많은 순
+        </button>
+      </div>
+
+      {/* 상품 그리드 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {currentItems.map((item) => (
+          <Item
+            key={item.id}
+            image={item.image}
+            title={item.title}
+            company={item.company}
+            price={item.price}
+          />
+        ))}
+      </div>
+
+      {/* 페이지네이션 컨트롤 */}
+      <div className="flex justify-center mt-4">
+        <button
+          className="flex items-center"
+          onClick={() => goToPrevPage()}
+          disabled={currentPage === 1}
+        >
+          <FaChevronLeft className="mr-2 text-[#2E9093]" />
+        </button>
+        <div className="flex">
+          {Array.from({ length: totalPages }, (_, index) => (
+            <button
+              key={index}
+              className={`px-2 py-2 rounded mr-2 ${currentPage === index + 1 ? 'text-[#2E9093] font-bold' : 'text-gray-400'}`}
+              onClick={() => paginate(index + 1)}
+            >
+              {index + 1}
+            </button>
+          ))}
+        </div>
+        <button
+          className="flex items-center"
+          onClick={() => goToNextPage()}
+          disabled={currentPage === totalPages}
+        >
+          <FaChevronRight className="ml-2 text-[#2E9093]" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ItemList;

--- a/src/components/ProductMain/PostButton.tsx
+++ b/src/components/ProductMain/PostButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const PostButton = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <button
+        onClick={() => navigate('/product/post')}
+        className="bg-[#5EC7B8] hover:bg-[#2E9093] text-white text-sm rounded px-2 py-2 mr-4 focus:outline-none focus:shadow-outline"
+      >
+        글 작성하기
+      </button>
+    </div>
+  );
+};
+
+export default PostButton;

--- a/src/components/ProductMain/index.ts
+++ b/src/components/ProductMain/index.ts
@@ -1,0 +1,5 @@
+import Banner from './Banner';
+import PostButton from './PostButton';
+import ItemList from './ItemList';
+
+export { Banner, PostButton, ItemList };

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -5,7 +5,7 @@ const SearchInput = () => {
   const searchInput = useInput({ initialValue: '' });
 
   return (
-    <form className="max-w-md flex items-center justify-end">
+    <form className="max-w-md w-full flex items-center justify-end ">
       <div className="relative w-full">
         <input
           type="text"

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,13 +1,158 @@
-import React from 'react';
-import SearchInput from '../components/SearchInput';
+import { Banner, ItemList, PostButton } from '../components/ProductMain';
+import SearchInput from '../hooks/useSearch';
 
-const Products = () => {
+interface ProductsProps {
+  isLoggedIn: boolean;
+  userType: 'user' | 'seller' | 'admin';
+}
+
+const Products: React.FC<ProductsProps> = ({ isLoggedIn, userType }) => {
+  // Dummy data
+  const items = [
+    {
+      id: 1,
+      image: '/asset/main-1-1.png',
+      title: '[누깍] FRODO 프로도 M 메신저백',
+      company: '누깍',
+      price: '30,000원',
+      mark: 120,
+      date: new Date('2024-06-24'),
+    },
+    {
+      id: 2,
+      image: '/asset/main-1-2.png',
+      title: '[니올] 하늘풍선 니올링 업사이클링 키링',
+      company: '니올',
+      price: '10,000원',
+      mark: 20,
+      date: new Date('2024-06-01'),
+    },
+    {
+      id: 3,
+      image: '/asset/main-1-3.png',
+      title: '[프라이탁] FREITAG F14 DEXTER 메신저 크로스백',
+      company: '프라이탁',
+      price: '50,000원',
+      mark: 290,
+      date: new Date('2024-05-04'),
+    },
+    {
+      id: 4,
+      image: '/asset/main-1-4.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 160,
+      date: new Date('2024-05-02'),
+    },
+    {
+      id: 5,
+      image: '/asset/p-5.png',
+      title: '[팩커블코] Waist Bag Medium',
+      company: '팩커블코',
+      price: '30,000원',
+      mark: 440,
+      date: new Date('2023-04-22'),
+    },
+    {
+      id: 6,
+      image: '/asset/p-6.png',
+      title: '[플리츠마마] 투웨이쇼퍼백 핑크그린',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 12,
+      date: new Date('2024-03-30'),
+    },
+    {
+      id: 7,
+      image: '/asset/p-7.png',
+      title: '[리버드] Reversible Gym Sack #10',
+      company: '리버드',
+      price: '30,000원',
+      mark: 40,
+      date: new Date('2024-03-22'),
+    },
+    {
+      id: 8,
+      image: '/asset/p-8.png',
+      title: '[기시히] 백팩 5',
+      company: '기시히',
+      price: '30,000원',
+      mark: 150,
+      date: new Date('2024-01-22'),
+    },
+    {
+      id: 9,
+      image: '/asset/com-2.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 9,
+      date: new Date('2024-01-12'),
+    },
+    {
+      id: 10,
+      image: '/asset/com-3.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 88,
+      date: new Date('2023-12-22'),
+    },
+    {
+      id: 11,
+      image: '/asset/com-4.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 5,
+      date: new Date('2023-11-22'),
+    },
+    {
+      id: 12,
+      image: '/asset/com-5.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 70,
+      date: new Date('2023-05-29'),
+    },
+    {
+      id: 13,
+      image: '/asset/main-1-3.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 18,
+      date: new Date('2023-01-02'),
+    },
+    {
+      id: 14,
+      image: '/asset/main-1-2.png',
+      title: '[플리츠마마] 숄더백 서울에디션 미드나잇',
+      company: '플리츠마마',
+      price: '30,000원',
+      mark: 255,
+      date: new Date('2022-01-02'),
+    },
+  ];
+
   return (
     <div>
-      리사이클링 물건 메인 페이지
+      {/* banner */}
+      <div className="mb-16">
+        <Banner />
+      </div>
+
       {/* search */}
-      <div className="mb-6 flex items-center justify-end mr-5">
+      <div className="mb-6 justify-end flex ml-4 mr-20">
+        {userType === 'seller' && <PostButton />}
         <SearchInput />
+      </div>
+
+      {/* 제품 리스트 */}
+      <div className="mb-6">
+        <ItemList items={items} />
       </div>
     </div>
   );

--- a/src/shared/Header.tsx
+++ b/src/shared/Header.tsx
@@ -2,11 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { FaShoppingCart } from 'react-icons/fa';
 import { FaRegUserCircle } from 'react-icons/fa';
 
-type HeaderProps = {
-  isLoggedIn: boolean;
-  userType: 'admin' | 'seller' | 'user';
-};
-
 const Header: React.FC<HeaderProps> = ({ isLoggedIn, userType }) => {
   const navigate = useNavigate();
 

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -39,7 +39,10 @@ const Router = () => {
         <Route path="/login" element={<Login />} />
 
         <Route path="/:companyid" element={<CompanyMain />} />
-        <Route path="/products" element={<Products />} />
+        <Route
+          path="/products"
+          element={<Products isLoggedIn={isLoggedIn} userType={userType} />}
+        />
         <Route path="/product/:productid" element={<ProductDetail />} />
         <Route path="/product/post" element={<ProductPost />} />
 

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -36,3 +36,8 @@ declare interface ProtectionItemProps {
   date: string;
   likes: number;
 }
+
+declare type HeaderProps = {
+  isLoggedIn: boolean;
+  userType: 'admin' | 'seller' | 'user';
+};


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#31 => develop
closed #31 

## 변경 사항
![localhost_3000_products](https://github.com/web-team-dopamine/recycling-front/assets/95006849/847b559e-1f4c-40f9-a22c-8b3c18f51c9b)
- 업체 홍보 banner (추후 carousel로 구현 예정)
- 검색창
- `글 작성하기` 버튼 (userType이 seller인 경우에만 나타나도록 조건 추가)
- 최신순 / 찜 많은 순 정렬
- 8개씩 나오도록 리스트 pagination