### PR TITLE
[UI] 장바구니 페이지 (#13)

### DIFF
--- a/src/components/Common/Pay/PayTitle.tsx
+++ b/src/components/Common/Pay/PayTitle.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface PayTitleProps {
+  section1?: string;
+  section2?: string;
+  section3?: string;
+}
+
+const PayTitle: React.FC<PayTitleProps> = ({
+  section1,
+  section2,
+  section3,
+}) => {
+  return (
+    <div className="flex max-w-screen-lg mx-auto mt-6 mb-16 justify-end">
+      <div
+        className={`${section1 ? 'font-semibold' : ''} ${section1 ? 'text-[#2E9093]' : 'text-[#868686]'} mr-4`}
+      >
+        ① 장바구니
+      </div>
+      <div
+        className={`${section2 ? 'font-semibold' : ''} ${section2 ? 'text-[#2E9093]' : 'text-[#868686]'} mr-4`}
+      >
+        ② 주문/결제
+      </div>
+      <div
+        className={`${section3 ? 'font-semibold' : ''} ${section3 ? 'text-[#2E9093]' : 'text-[#868686]'} mr-4`}
+      >
+        ③ 결제완료
+      </div>
+    </div>
+  );
+};
+
+export default PayTitle;

--- a/src/components/Common/index.ts
+++ b/src/components/Common/index.ts
@@ -4,6 +4,7 @@ import EditorComponent from './Post/EditorComponent';
 import EditorToolbar from './Post/EditorToolbar';
 import EditButton from './Post/EditButton';
 import TitleInput from './Post/TitleInput';
+import PayTitle from './Pay/PayTitle';
 
 export {
   Banner,
@@ -12,4 +13,5 @@ export {
   EditorToolbar,
   EditButton,
   TitleInput,
+  PayTitle,
 };

--- a/src/components/MyBasket/BasketItem.tsx
+++ b/src/components/MyBasket/BasketItem.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { FaMinus, FaPlus } from 'react-icons/fa';
+import { MdCheckBoxOutlineBlank, MdCheckBox } from 'react-icons/md';
+import { MdDelete } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+
+interface BasketItemProps {
+  image: string;
+  productName: string;
+  quantity: number;
+  price: number;
+  isChecked: boolean;
+  onChangeQuantity: (quantity: number) => void;
+  onDelete: () => void;
+  onCheckboxChange: () => void;
+}
+
+const BasketItem: React.FC<BasketItemProps> = ({
+  image,
+  productName,
+  quantity,
+  price,
+  isChecked,
+  onChangeQuantity,
+  onDelete,
+  onCheckboxChange,
+}) => {
+  const navigate = useNavigate();
+
+  const handleCheckBoxClick = () => {
+    onCheckboxChange();
+  };
+
+  const handleIncrease = () => {
+    onChangeQuantity(quantity + 1);
+  };
+
+  const handleDecrease = () => {
+    if (quantity > 1) {
+      onChangeQuantity(quantity - 1);
+    }
+  };
+
+  const handleDelete = () => {
+    onDelete();
+  };
+
+  const totalPrice = price * quantity;
+
+  return (
+    <div className="flex items-center py-4">
+      {/* Checkbox */}
+      <div className="flex items-center justify-center w-1/12">
+        {isChecked ? (
+          <MdCheckBox
+            className="w-6 h-6 text-[#2E9093] cursor-pointer"
+            onClick={handleCheckBoxClick}
+          />
+        ) : (
+          <MdCheckBoxOutlineBlank
+            className="w-6 h-6 text-gray-400 cursor-pointer"
+            onClick={handleCheckBoxClick}
+          />
+        )}
+      </div>
+
+      {/* Product Image and Name */}
+      <div className="flex items-center w-6/12">
+        {/* Product Image */}
+        <img
+          src={image}
+          alt={productName}
+          className="w-20 h-20 object-cover rounded mr-4"
+        />
+        <p
+          className="text-l font-semibold hover:underline cursor-pointer"
+          onClick={() => navigate('/product/:id')}
+        >
+          {productName}
+        </p>
+      </div>
+
+      {/* Quantity controls */}
+      <div className="flex items-center justify-center w-3/12">
+        <button onClick={handleDecrease} className="px-2 py-1">
+          <FaMinus />
+        </button>
+        <span className="px-2 py-1 bg-white border text-sm">{quantity}</span>
+        <button onClick={handleIncrease} className="px-2 py-1">
+          <FaPlus />
+        </button>
+      </div>
+
+      {/* Total Price */}
+      <div className="text-l text-right w-2/12">
+        {totalPrice.toLocaleString()}원
+      </div>
+
+      {/* 삭제 버튼 */}
+      <div className=" text-right w-2/12">
+        <button className="mr-1" onClick={handleDelete}>
+          <MdDelete className="w-5 h-5 hover:text-[#2E9093]" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BasketItem;

--- a/src/components/MyBasket/BasketNotice.tsx
+++ b/src/components/MyBasket/BasketNotice.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const BasketNotice = () => {
+  return (
+    <ul className="bg-white border border-gray-200 rounded-lg px-8 py-4 m-3 mt-14 list-disc list-inside text-sm text-gray-500">
+      <li className="mb-2">바구니 상품은 최대 90일간 저장됩니다.</li>
+      <li className="mb-2">
+        가격, 옵션 등 정보가 변경된 경우 주문이 불가할 수 있습니다.
+      </li>
+      <li className="mb-2">
+        오늘출발 정보는 판매자가 설정한 정보에 의해 제공되며, 물류위탁 상품인
+        경우 물류사의 사정에 따라 실제와 다를 수 있습니다.
+      </li>
+      <li>
+        일부 상품의 경우 카드 할부기간이 카드사 제공 기간보다 적게 제공될 수
+        있습니다.
+      </li>
+    </ul>
+  );
+};
+
+export default BasketNotice;

--- a/src/components/MyBasket/CheckButton.tsx
+++ b/src/components/MyBasket/CheckButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface CheckButtonPros {
+  onSelectAll: () => void;
+  onDeleteAll: () => void;
+}
+
+const CheckButton: React.FC<CheckButtonPros> = ({
+  onSelectAll,
+  onDeleteAll,
+}) => {
+  return (
+    <div className="flex items-center justify-between py-4">
+      <div>
+        <button
+          onClick={onSelectAll}
+          className="bg-[#5EC7B8] hover:bg-opacity-80 text-white border rounded px-4 py-2 m-4"
+        >
+          전체선택
+        </button>
+        <button
+          onClick={onDeleteAll}
+          className="bg-[#D9D9D9] hover:bg-opacity-80 text-white border rounded px-4 py-2"
+        >
+          전체삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CheckButton;

--- a/src/components/MyBasket/PaySummary.tsx
+++ b/src/components/MyBasket/PaySummary.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { GoPlus } from 'react-icons/go';
+import { FaEquals } from 'react-icons/fa6';
+
+interface PaySummaryProps {
+  totalAmount: number;
+  onOrder: () => void;
+}
+
+const PaySummary: React.FC<PaySummaryProps> = ({ totalAmount, onOrder }) => {
+  const shippingFee = totalAmount > 0 && totalAmount < 50000 ? 3000 : 0;
+  const totalCost = totalAmount + shippingFee;
+
+  return (
+    <div className="max-w-screen-lg mx-auto mt-2 pt-4 border">
+      <div className="flex justify-end items-center">
+        <div className="mr-3">
+          총 상품 금액{' '}
+          <span className="font-bold">{totalAmount.toLocaleString()}원</span>
+        </div>
+        <div className="mr-2">
+          <GoPlus />
+        </div>
+        <div className="mr-3">
+          배송비{' '}
+          <span className="font-bold">{shippingFee.toLocaleString()}원</span>
+        </div>
+      </div>
+
+      <div className="flex justify-end font-bold text-lg m-4 items-center">
+        <FaEquals className="mr-3" /> {totalCost.toLocaleString()}원
+      </div>
+      <div className="flex justify-end mt-6 mb-4 mr-3">
+        <button
+          onClick={onOrder}
+          className="w-1/4 bg-[#2E9093] hover:bg-opacity-80 text-white font-bold px-6 py-2 rounded"
+        >
+          주문하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PaySummary;

--- a/src/components/MyBasket/index.ts
+++ b/src/components/MyBasket/index.ts
@@ -1,0 +1,6 @@
+import BasketItem from './BasketItem';
+import BasketNotice from './BasketNotice';
+import CheckButton from './CheckButton';
+import PaySummary from './PaySummary';
+
+export { BasketItem, BasketNotice, CheckButton, PaySummary };

--- a/src/pages/MyBasket.tsx
+++ b/src/pages/MyBasket.tsx
@@ -1,7 +1,138 @@
-import React from "react";
+import React, { useEffect, useState } from 'react';
+import { PayTitle } from '../components/Common';
+import {
+  BasketItem,
+  BasketNotice,
+  CheckButton,
+  PaySummary,
+} from '../components/MyBasket';
+import { useNavigate } from 'react-router-dom';
 
 const MyBasket = () => {
-  return <div>장바구니 페이지</div>;
+  const navigate = useNavigate();
+
+  const [cartItems, setCartItems] = useState([
+    {
+      id: 1,
+      image: '/asset/main-1-2.png',
+      productName: '[니올] 하늘풍선 니올링 업사이클링 키링',
+      quantity: 1,
+      price: 20000,
+      isChecked: false,
+    },
+    {
+      id: 2,
+      image: '/asset/p-8.png',
+      productName: '[기시히] 백팩 5',
+      quantity: 1,
+      price: 60000,
+      isChecked: false,
+    },
+  ]);
+
+  const handleQuantityChange = (id: number, quantity: number) => {
+    setCartItems((prevItems) =>
+      prevItems.map((item) => (item.id === id ? { ...item, quantity } : item)),
+    );
+  };
+
+  useEffect(() => {
+    // update total amount
+    calculateTotalAmount();
+  }, [cartItems]);
+
+  const handleSelectAll = () => {
+    const allChecked = cartItems.every((item) => item.isChecked);
+    setCartItems((prevItems) =>
+      prevItems.map((item) => ({
+        ...item,
+        isChecked: !allChecked,
+      })),
+    );
+  };
+
+  const handleDeleteAll = () => {
+    setCartItems([]);
+  };
+
+  const calculateTotalAmount = () => {
+    const total = cartItems.reduce(
+      (acc, item) => (item.isChecked ? acc + item.quantity * item.price : acc),
+      0,
+    );
+    return total;
+  };
+
+  const handleOrder = () => {
+    navigate('/user/:id/pay');
+  };
+
+  const handleDeleteItem = (id: number) => {
+    setCartItems((prevItems) => prevItems.filter((item) => item.id !== id));
+  };
+
+  const handleCheckboxChange = (id: number) => {
+    setCartItems((prevItems) =>
+      prevItems.map((item) =>
+        item.id === id ? { ...item, isChecked: !item.isChecked } : item,
+      ),
+    );
+  };
+
+  const isCartEmpty = cartItems.length === 0;
+
+  return (
+    <div className="max-w-screen-lg mx-auto mt-6 mb-16">
+      <PayTitle section1="#2E9093" />
+
+      <div className="text-2xl font-semibold m-4 text-[#2E9093]">장바구니</div>
+
+      <div className="border-b"></div>
+
+      {isCartEmpty ? (
+        <div className="text-center h-28 my-8 text-gray-500 bg-white flex justify-center items-center">
+          장바구니가 비었습니다
+        </div>
+      ) : (
+        <>
+          {/* 장바구니에 담긴 items */}
+          {cartItems.map((item) => (
+            <BasketItem
+              key={item.id}
+              image={item.image}
+              productName={item.productName}
+              quantity={item.quantity}
+              price={item.price}
+              isChecked={item.isChecked}
+              onChangeQuantity={(quantity) =>
+                handleQuantityChange(item.id, quantity)
+              }
+              onDelete={() => handleDeleteItem(item.id)}
+              onCheckboxChange={() => handleCheckboxChange(item.id)}
+            />
+          ))}
+        </>
+      )}
+
+      <div className="border-b"></div>
+
+      <div className="flex justify-end text-xs text-red-400 mt-2 mb-2">
+        * 50,000원 이상 주문 시 배송비 무료입니다. (기본 배송비: 3,000원)
+      </div>
+
+      {/* 전체 선택/ 선체 삭제 버튼 */}
+      <CheckButton
+        onSelectAll={handleSelectAll}
+        onDeleteAll={handleDeleteAll}
+      />
+
+      {/* 총 상품 금액 / 배송비 / 주문하기 버튼*/}
+      <PaySummary totalAmount={calculateTotalAmount()} onOrder={handleOrder} />
+
+      {/* 장바구니 안내 문구 */}
+      <BasketNotice />
+    </div>
+  );
 };
 
 export default MyBasket;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#13 => develop
closed #13 

## 변경 사항
![localhost_3000_user__id_basket](https://github.com/web-team-dopamine/recycling-front/assets/95006849/1182c8e1-4905-4b71-9f7e-7c9ed0763cbe)
- 장바구니 내부 상품
- `전체선택`, `전체삭제` 버튼
   - `전체삭제` 클릭 시 장바구니 상품 전체 삭제 ('상품이 없습니다' 문구 추가) 
- 체크 여부에 따른 총 상품 비용, 배송비 계산 (50,000원 이상이면 배송비 무료 조건)
- `결제하기` 버튼 클릭 시 결제 페이지로 이동
- 장바구니 관련 안내 문구