### PR TITLE
[UI] 결제 완료 페이지 

### DIFF
--- a/src/pages/PayEnd.tsx
+++ b/src/pages/PayEnd.tsx
@@ -1,7 +1,36 @@
-import React from "react";
+import React from 'react';
+import { PayTitle } from '../components/Common';
+import { useNavigate } from 'react-router-dom';
 
 const PayEnd = () => {
-  return <div>결제 완료 페이지</div>;
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-screen-lg mx-auto mt-6 mb-16">
+      <PayTitle section3="#2E9093" />
+
+      <div className="flex items-center justify-center flex-col  h-[600px]">
+        <h1 className="text-2xl font-semibold m-4">결제가 완료되었습니다!</h1>
+        <h1 className="text-2xl font-semibold m-4 text-[#2E9093]">
+          주문 및 배송 관련은{' '}
+          <button
+            className="underline hover:text-[#ACDACD]"
+            onClick={() => navigate('/mypage')}
+          >
+            마이페이지
+          </button>
+          를 통해 확인
+        </h1>
+        <h1 className="text-2xl font-semibold m-4">하실 수 있습니다.</h1>
+        <button
+          onClick={() => navigate('/')}
+          className="bg-[#2E9093] hover:bg-opacity-80 w-1/4 text-white border rounded-lg px-4 py-2 m-6"
+        >
+          메인 페이지로 이동
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default PayEnd;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#16 => develop

closed #16 

## 변경 사항
![localhost_3000_user__id_payend](https://github.com/web-team-dopamine/recycling-front/assets/95006849/df89fa83-7dbc-4c17-a359-93a7a6e7797b)
- `마이페이지`로 이동 가능
- `메인 페이지`로 이동 가능