### PR TITLE
[UI] 찜한 제품 리스트 페이지 UI (#18)

### DIFF
--- a/src/components/MyBookMark/BookMarkItem.tsx
+++ b/src/components/MyBookMark/BookMarkItem.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface BookmarkItemProps {
+  index: number; // Bookmark number (order)
+  productName: string;
+  companyName: string;
+  price: number;
+  reviewCount: number;
+}
+
+const BookmarkItem: React.FC<BookmarkItemProps> = ({
+  index,
+  productName,
+  companyName,
+  price,
+  reviewCount,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="p-4 border-t">
+      <div className="flex items-center">
+        <p className="mr-4 w-12">{index}</p>
+        <div className="flex justify-between w-full">
+          <div
+            className="font-bold w-2/6 cursor-pointer hover:underline"
+            onClick={() => navigate('/product/:productid')}
+          >
+            {productName}
+          </div>
+          <div className="w-2/6">{companyName}</div>
+          <div className="text-gray-600 w-1/6">{price.toLocaleString()}원</div>
+          <div className="text-gray-600 w-1/6">리뷰 {reviewCount}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookmarkItem;

--- a/src/components/MyBookMark/BookMarkList.tsx
+++ b/src/components/MyBookMark/BookMarkList.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import usePagination from '../../hooks/usePagination';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import BookmarkItem from './BookMarkItem';
+
+interface Product {
+  id: number;
+  productName: string;
+  companyName: string;
+  price: number;
+  reviewCount: number;
+}
+
+interface MyBookMarkProps {
+  products: Product[];
+}
+
+const BookMarkList: React.FC<MyBookMarkProps> = ({ products }) => {
+  const itemsPerPage = 10;
+  const {
+    currentPage,
+    currentItems,
+    paginate,
+    totalPages,
+    goToPrevPage,
+    goToNextPage,
+  } = usePagination(products, itemsPerPage);
+
+  return (
+    <div className="mb-8 h-screen flex flex-col justify-center">
+      <div className="text-xl font-semibold m-4 p-4 text-[#2E9093]">
+        찜한 제품 리스트
+      </div>
+
+      <div className="p-4 rounded-lg m-4">
+        {currentItems.map((product, index) => (
+          <BookmarkItem
+            key={product.id}
+            index={(currentPage - 1) * itemsPerPage + index + 1}
+            productName={product.productName}
+            companyName={product.companyName}
+            price={product.price}
+            reviewCount={product.reviewCount}
+          />
+        ))}
+      </div>
+
+      {/* Pagination controls */}
+      <div className="flex justify-center mt-4">
+        <button
+          className="flex items-center"
+          onClick={() => goToPrevPage()}
+          disabled={currentPage === 1}
+        >
+          <FaChevronLeft className="mr-2 text-[#2E9093]" />
+        </button>
+        <div className="flex">
+          {Array.from({ length: totalPages }, (_, index) => (
+            <button
+              key={index}
+              className={`px-2 py-2 rounded mr-2 ${
+                currentPage === index + 1
+                  ? 'text-[#2E9093] font-bold'
+                  : 'text-gray-400'
+              }`}
+              onClick={() => paginate(index + 1)}
+            >
+              {index + 1}
+            </button>
+          ))}
+        </div>
+        <button
+          className="flex items-center"
+          onClick={() => goToNextPage()}
+          disabled={currentPage === totalPages}
+        >
+          <FaChevronRight className="ml-2 text-[#2E9093]" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BookMarkList;

--- a/src/pages/MyBookMark.tsx
+++ b/src/pages/MyBookMark.tsx
@@ -1,7 +1,99 @@
-import React from "react";
+import React from 'react';
+import BookMarkList from '../components/MyBookMark/BookMarkList';
 
 const MyBookMark = () => {
-  return <div>bookmark page</div>;
+  const products = [
+    {
+      id: 1,
+      productName: '아이폰 12 Pro',
+      companyName: 'Apple',
+      price: 1500000,
+      reviewCount: 120,
+    },
+    {
+      id: 2,
+      productName: '갤럭시 S21 Ultra',
+      companyName: 'Samsung',
+      price: 1400000,
+      reviewCount: 90,
+    },
+    {
+      id: 3,
+      productName: '맥북 프로 2021',
+      companyName: 'Apple',
+      price: 2500000,
+      reviewCount: 80,
+    },
+    {
+      id: 4,
+      productName: '아이패드 프로',
+      companyName: 'Apple',
+      price: 1200000,
+      reviewCount: 100,
+    },
+    {
+      id: 5,
+      productName: 'LG 그램',
+      companyName: 'LG',
+      price: 1800000,
+      reviewCount: 60,
+    },
+    {
+      id: 6,
+      productName: '소니 알파 A7 III',
+      companyName: 'Sony',
+      price: 2000000,
+      reviewCount: 70,
+    },
+    {
+      id: 7,
+      productName: '닌텐도 스위치',
+      companyName: 'Nintendo',
+      price: 300000,
+      reviewCount: 150,
+    },
+    {
+      id: 8,
+      productName: '아마존 에코',
+      companyName: 'Amazon',
+      price: 150000,
+      reviewCount: 200,
+    },
+    {
+      id: 9,
+      productName: '구글 픽셀 5',
+      companyName: 'Google',
+      price: 900000,
+      reviewCount: 50,
+    },
+    {
+      id: 10,
+      productName: '로지텍 MX 마스터 3',
+      companyName: 'Logitech',
+      price: 150000,
+      reviewCount: 120,
+    },
+    {
+      id: 11,
+      productName: '로지텍 MX 마스터 3',
+      companyName: 'Logitech',
+      price: 150000,
+      reviewCount: 120,
+    },
+    {
+      id: 12,
+      productName: '로지텍 MX 마스터 3',
+      companyName: 'Logitech',
+      price: 150000,
+      reviewCount: 120,
+    },
+  ];
+
+  return (
+    <div className="max-w-screen-lg mx-auto mt-6 mb-16">
+      <BookMarkList products={products} />
+    </div>
+  );
 };
 
 export default MyBookMark;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#18 => develop
closed #18 

## 변경사항
![localhost_3000_user__id_bookmark](https://github.com/web-team-dopamine/recycling-front/assets/95006849/a7aff0aa-eefb-4c63-9086-3fe48d988614)
- 찜(하트)를 누른 제품들 리스트 구현
- 상품명/회사명/가격/리뷰 수가 나오도록 구현
- 10개씩 pagination
- 상품명 클릭 시 해당 상품 상세 페이지로 이동
